### PR TITLE
1.7.10 Small bugfixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,10 @@ buildscript {
     repositories {
         mavenCentral()
         maven {
+            name = "central"
+            url = "https://repo1.maven.org/maven2/"
+        }
+        maven {
             name = "forge"
             url = "http://files.minecraftforge.net/maven"
         }
@@ -38,6 +42,10 @@ minecraft {
 }
 
 repositories {
+    maven  {
+        name = "central"
+        url = "https://repo1.maven.org/maven2/"
+    }
     maven {
         name = "Chicken-Bones"
         url = "http://chickenbones.net/maven"
@@ -71,11 +79,11 @@ processResources
     // replace stuff in mcmod.info, nothing else
     from(sourceSets.main.resources.srcDirs) {
         include 'mcmod.info'
-                
+
         // replace version and mcversion
         expand 'version':project.version, 'mcversion':project.minecraft.version
     }
-        
+
     // copy everything else, thats not the mcmod.info
     from(sourceSets.main.resources.srcDirs) {
         exclude 'mcmod.info'

--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,4 @@
-mod_version=1.3
+mod_version=1.4
 mc_version=1.7.10
 forge_version=10.13.4.1614-1.7.10
 exnihilo_version=1.38-49

--- a/build.properties
+++ b/build.properties
@@ -2,4 +2,4 @@ mod_version=1.3
 mc_version=1.7.10
 forge_version=10.13.4.1614-1.7.10
 exnihilo_version=1.38-49
-excompressum_version=1.1.54
+excompressum_version=1.2.0

--- a/src/main/java/knightminer/knightperipherals/turtles/TurtleHammerCompressed.java
+++ b/src/main/java/knightminer/knightperipherals/turtles/TurtleHammerCompressed.java
@@ -24,7 +24,7 @@ public class TurtleHammerCompressed extends TurtleHammer {
 	// Reward list
 	@Override
 	protected Collection<Smashable> getRewards(Block block, int meta) {
-		return CompressedHammerRegistry.getRewards(block, meta);
+		return CompressedHammerRegistry.getSmashables(block, meta);
 	}
 
 	// Config boolean

--- a/src/main/java/knightminer/knightperipherals/util/LuaTimer.java
+++ b/src/main/java/knightminer/knightperipherals/util/LuaTimer.java
@@ -35,9 +35,13 @@ public class LuaTimer {
 				Entry<IComputerAccess, Integer[]> timer = iterator.next();
 				Integer[] data = timer.getValue();
 				data[0] -= 1;
-				if (data[0] < 1) { // check less than rather than equals just in
-				                   // case
-					timer.getKey().queueEvent(TIMER_EVENT, new Object[] { TIMER_TOKEN + data[1] });
+				if (data[0] < 1) { // check less than rather than equals just in case
+					try {
+						timer.getKey().queueEvent(TIMER_EVENT, new Object[] { TIMER_TOKEN + data[1] });
+					}
+					catch (RuntimeException e) { // Peripheral detached after timer started
+						continue; // Ignore exception
+					}
 					iterator.remove();
 				}
 				else {

--- a/src/main/java/knightminer/knightperipherals/util/LuaTimer.java
+++ b/src/main/java/knightminer/knightperipherals/util/LuaTimer.java
@@ -10,6 +10,7 @@ import cpw.mods.fml.common.gameevent.TickEvent.Phase;
 import cpw.mods.fml.common.gameevent.TickEvent.ServerTickEvent;
 import dan200.computercraft.api.lua.ILuaContext;
 import dan200.computercraft.api.peripheral.IComputerAccess;
+import knightminer.knightperipherals.KnightPeripherals;
 
 public class LuaTimer {
 	private static final String TIMER_EVENT = "computer_timer";
@@ -40,7 +41,8 @@ public class LuaTimer {
 						timer.getKey().queueEvent(TIMER_EVENT, new Object[] { TIMER_TOKEN + data[1] });
 					}
 					catch (RuntimeException e) { // Peripheral detached after timer started
-						continue; // Ignore exception
+						KnightPeripherals.logger.warn("LuaTimer expired after peripheral detached. CC Exception:" + e.getMessage());
+						continue;
 					}
 					iterator.remove();
 				}


### PR DESCRIPTION
It looks like the claw crash was caused by the timer expiring after the turtle unloads, causing IComputerAccess.queueEvent to throw. Perhaps it's not the best solution, but I simply catch the exception and ignore it.

```Java
try {
    timer.getKey().queueEvent(TIMER_EVENT, new Object[] { TIMER_TOKEN + data[1] });
}
catch (RuntimeException e) { // Peripheral detached after timer started
    continue; // Ignore exception
}
```

Fixes #3, Fixes #7